### PR TITLE
When the window(frame) close button pressed, forcibly quit app.

### DIFF
--- a/src/main/java/org/zplet/ZJApp.java
+++ b/src/main/java/org/zplet/ZJApp.java
@@ -6,6 +6,8 @@
 package org.zplet;
 
 import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.net.*;
 import java.io.*;
 
@@ -61,6 +63,13 @@ public class ZJApp extends Frame {
 				+ myz.getBounds().y);
 		// myz.move(0,40);
 		System.err.println("Parent = " + myz.getParent());
+
+		myz.addWindowListener(new WindowAdapter() {
+			public void windowClosing(WindowEvent e) {
+				System.exit(0);
+			}
+		});
+
 		myz.setTitle("ZJApp");
 		myz.pack();
 		myz.setVisible(true);


### PR DESCRIPTION
Hello.  I'm not sure I'm 100% happy with this change, but I thought I'd offer it.  The fact is, I got annoyed at having to type `quit`, then answering `y`, each time I needed to exit the application when testing it, and wanted a quicker way to quit.  So I added a close button.  The reason I'm not 100% happy with it, is that the close button quits the app immediately.  It would be somewhat more graceful if it asked you to confirm that first, with a dialog box, but I haven't been motivated enough yet to look up how you do that in Java.