### PR TITLE
Allow creating jarfile, embedding storyfiles in it

### DIFF
--- a/manifest.txt
+++ b/manifest.txt
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Application-Name: Zplet
+Specification-Title: Zplet
+Specification-Version: 0.1
+Specification-Vendor: zplet.org
+Implementation-Title: Zplet
+Implementation-Version: 0.1
+Implementation-Vendor: zplet.org
+Main-Class: org.zplet.ZJApp
+Permissions: sandbox

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,6 +11,9 @@ zplet: ../classes
 zjapp: ../classes
 	javac $(JCFLAGS) -sourcepath $(PWD)/main/java -d ../classes main/java/org/zplet/ZJApp.java
 
+zplet.jar: zplet zjapp
+	cd ../classes && jar cvfm ../$@ ../manifest.txt org/zplet/*.class org/zplet/*/*.class org/zplet/*/*/*.class $(EXTRAJARFILES)
+
 clean:
 	find ../classes -type f -exec rm "{}" \;	
 	find . -name "*~" -exec rm "{}" \;

--- a/src/main/java/org/zplet/ZJApp.java
+++ b/src/main/java/org/zplet/ZJApp.java
@@ -111,9 +111,14 @@ public class ZJApp extends Frame {
 		zmemimage = null;
 		try {
 			System.err.println(zcodefile);
-			myzzurl = new URL(zcodefile);
-			myzstream = myzzurl.openStream();
-			zmemimage = suckstream(myzstream);
+			myzzurl = getClass().getClassLoader().getResource(zcodefile);
+			if (myzzurl == null) {
+				myzzurl = new URL(zcodefile);
+			}
+			if (myzzurl != null) {
+				myzstream = myzzurl.openStream();
+				zmemimage = suckstream(myzstream);
+			}
 		} catch (MalformedURLException booga) {
 			try {
 				myzstream = new FileInputStream(zcodefile);


### PR DESCRIPTION
Hello.  These changes allow someone who is using the `Makefile`, to build a jarfile which contains ZPlet plus any other files they wish to include (by setting the `EXTRAJARFILES` environment variable before running `make`.)  It also first attempts to load the specified storyfile as a resource (i.e. from the jarfile), before trying it in the existing ways (fetching from a URL.)  The practical upshot is that one or more storyfiles can be bundled along with ZPlet in the jarfile.

(Java Applets are basically obsolete now, but jarfiles can still be used with Java Web Start with an appropriate JNLP file, and that's what I'm doing here: http://catseye.tc/installation/The_Never-Ending_Maze .  That's why `zjapp` is included in the jar, and why `org.zplet.ZJApp` is listed in the manifest.)

(This change applies to the Makefile only; I don't typically use ant so I haven't updated the antfile to match.)